### PR TITLE
require bindle-server

### DIFF
--- a/run_servers.sh
+++ b/run_servers.sh
@@ -14,7 +14,7 @@ require() {
 require nomad
 require consul
 require vault
-require bindle
+require bindle-server
 
 cleanup() {
   echo


### PR DESCRIPTION
The nomad job relies on bindle-server being present, not bindle.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>