### PR TITLE
use local traefik instance

### DIFF
--- a/job/traefik.nomad
+++ b/job/traefik.nomad
@@ -31,12 +31,6 @@ job "traefik" {
     task "traefik" {
       driver = "raw_exec"
 
-      # PRO TIP: Comment out the artifact block if you have the traefik binary
-      # on your local machine for faster startup time
-      artifact {
-        source = "https://github.com/traefik/traefik/releases/download/v2.5.4/traefik_v2.5.4_${attr.os.name}_${attr.cpu.arch}.tar.gz"
-      }
-
       config {
         command = "traefik"
         args = [

--- a/run_servers.sh
+++ b/run_servers.sh
@@ -11,10 +11,11 @@ require() {
   fi
 }
 
-require nomad
-require consul
-require vault
 require bindle
+require consul
+require nomad
+require traefik
+require vault
 
 cleanup() {
   echo


### PR DESCRIPTION
This change runs the traefik job identical to the bindle-server job. I removed the `artifact` stanza because `${attr.os.name}` is passed directly to the URl (broken), and the version of traefik being fetched is a few months out of date anyways (2.5.4 was released last November).