### PR TITLE
fix: add `--preserve-env=PATH` to `sudo` command

### DIFF
--- a/run_servers.sh
+++ b/run_servers.sh
@@ -65,7 +65,7 @@ fi
 # https://github.com/deislabs/hippo/blob/de73ae52d606c0a2351f90069e96acea831281bc/src/Infrastructure/Jobs/NomadJob.cs#L28
 # https://www.nomadproject.io/docs/drivers/exec#client-requirements
 case "$OSTYPE" in
- linux*) SUDO=sudo ;;
+ linux*) SUDO="sudo --preserve-env=PATH" ;;
  *) SUDO= ;;
 esac
 


### PR DESCRIPTION
Previously, run_servers.sh would check that all the necessary prerequisites are
in the current shell's PATH, but since most of them are actually run via sudo,
what we really care about is whether those prerequisites are in *root's* PATH.
Now we check root's PATH for those things before proceeding.

This is important because the user may have installed Spin or Bindle using
`cargo install`, which only installs things for the current user, not system-wide.

Signed-off-by: Joel Dice <joel.dice@gmail.com>